### PR TITLE
HTTP response nil check

### DIFF
--- a/limelight/resource_limelight_delivery.go
+++ b/limelight/resource_limelight_delivery.go
@@ -145,7 +145,7 @@ func resourceLimelightDeliveryRead(d *schema.ResourceData, m interface{}) error 
 	deliveryServiceInstance, resp, err := c.GetDeliveryServiceInstance(d.Id())
 
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			log.Printf("[INFO] Delivery configuration %s not found", d.Id())
 			d.SetId("")
 			return nil

--- a/limelight/resource_limelight_delivery_test.go
+++ b/limelight/resource_limelight_delivery_test.go
@@ -128,7 +128,7 @@ func testAccLimelightDeliveryCheckDestroy(state *terraform.State) error {
 		_, resp, err := client.GetDeliveryServiceInstance(resourceID)
 
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 			return fmt.Errorf("error retrieving delivery configuration with ID %s. Error: %v", resourceID, err)

--- a/limelight/resource_limelight_edgefunction.go
+++ b/limelight/resource_limelight_edgefunction.go
@@ -158,7 +158,7 @@ func resourceLimelightEdgeFunctionRead(d *schema.ResourceData, m interface{}) er
 	edgeFunction, resp, err := c.GetEdgeFunction(name, shortname)
 
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			log.Printf("[INFO] EdgeFunction %s was not found", name)
 			d.SetId("")
 			return nil

--- a/limelight/resource_limelight_edgefunction_alias.go
+++ b/limelight/resource_limelight_edgefunction_alias.go
@@ -90,7 +90,7 @@ func resourceLimelightEdgeFunctionAliasRead(d *schema.ResourceData, m interface{
 	aliasResponse, resp, err := client.GetEdgeFunctionAlias(fnName, shortname, aliasName)
 
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			log.Printf("[INFO] Alias %s for EdgeFunction %s was not found", aliasName, fnName)
 			d.SetId("")
 			return nil

--- a/limelight/resource_limelight_edgefunction_alias_test.go
+++ b/limelight/resource_limelight_edgefunction_alias_test.go
@@ -117,7 +117,7 @@ func testAccLimelightEdgeFunctionAliasCheckDestroy(state *terraform.State) error
 
 		_, resp, err := client.GetEdgeFunctionAlias(fnName, shortname, aliasName)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 			return fmt.Errorf("error retrieving EdgeFunction Alias with ID %s. Error: %v", resourceID, err)

--- a/limelight/resource_limelight_edgefunction_test.go
+++ b/limelight/resource_limelight_edgefunction_test.go
@@ -136,7 +136,7 @@ func testAccLimelightEdgeFunctionCheckDestroy(state *terraform.State, fnName str
 
 		_, resp, err := client.GetEdgeFunction(name, shortname)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 			return fmt.Errorf("error retrieving EdgeFunction with ID %s. Error: %v", resourceID, err)

--- a/limelight/resource_limelight_realtime_streaming_slot.go
+++ b/limelight/resource_limelight_realtime_streaming_slot.go
@@ -135,7 +135,7 @@ func resourceLimelightRealtimeStreamingSlotRead(d *schema.ResourceData, m interf
 	realtimeStreamingSlot, resp, err := c.GetRealtimeStreamingSlot(slotID, shortname)
 
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			log.Printf("[INFO] Realtime Streaming Slot %s not found", slotID)
 			d.SetId("")
 			return nil
@@ -193,7 +193,7 @@ func waitForLimelightRealtimeStreamingSlotProvision(d *schema.ResourceData, m in
 		Refresh: func() (interface{}, string, error) {
 
 			realtimeStreamingSlot, resp, err := client.GetRealtimeStreamingSlot(slotID, shortname)
-			if err != nil && resp.StatusCode == http.StatusNotFound {
+			if err != nil && resp != nil && resp.StatusCode == http.StatusNotFound {
 				d.Set("state", "NOT_FOUND")
 				return nil, "NOT_FOUND", err
 			}

--- a/limelight/resource_limelight_realtime_streaming_slot_test.go
+++ b/limelight/resource_limelight_realtime_streaming_slot_test.go
@@ -94,7 +94,7 @@ func testAccLimelightRealtimeStreamingSlotCheckDestroy(state *terraform.State) e
 		_, resp, err := client.GetRealtimeStreamingSlot(slotID, shortname)
 
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 			return fmt.Errorf("error retrieving Realtime Streaming Slot with ID %s. Error: %v", resourceID, err)
@@ -131,7 +131,7 @@ func testAccLimelightRealtimeStreamingSlotExists(testResourceName string) resour
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("rrror while checking if Realtime Streaming Slot %s exists. HTTP return code was %d", resourceID, resp.StatusCode)
+			return fmt.Errorf("error while checking if Realtime Streaming Slot %s exists. HTTP return code was %d", resourceID, resp.StatusCode)
 		}
 
 		if slot.Id == slotID {


### PR DESCRIPTION
There is currently an assumption that if an error is returned from one of the _Get_ function invocations, there will also be a non-nil HTTP response too. This is not always the case (i.e. in the case of a SSL/TLS error, or TCP connection failure), so we must defensively check before accessing the status code.