### PR TITLE
Fix handling of numeric option parameters

### DIFF
--- a/limelight/resource_limelight_delivery.go
+++ b/limelight/resource_limelight_delivery.go
@@ -234,7 +234,12 @@ func flattenOptions(expandedOptions []configuration.Option) []map[string]interfa
 		m["name"] = v.Name
 		params := make([]string, len(v.Parameters), len(v.Parameters))
 		for j, p := range v.Parameters {
-			params[j] = fmt.Sprintf("%v", p)
+			switch p.(type) {
+			case float64:
+				params[j] = fmt.Sprintf("%.0f", p)
+			default:
+				params[j] = fmt.Sprintf("%v", p)
+			}
 		}
 		m["parameters"] = params
 		flattenedOptions[i] = m


### PR DESCRIPTION
When the response from Config API is unmarshaled from JSON, numbers are represented as `float64`. Due to constraints with the provider schema, it is not possible to have a list containing multiple types. This means that when flattening the options parameter list (which can contain mixed types), we have to represent the values as `string` types. For small numbers this behaves as expected, but for larger values, the `%v` verb causes scientific notation to be used, resulting in a bug which causes an anomaly as shown in the following example:
```
  ~ option {
        name       = "refresh_absmin"
      ~ parameters = [
          - "2.592e+06",
          + "2592000",
        ]
    }
```
This PR contains a minor code change which uses a type switch to convert a `float64` to `string` using a different format specifier: `%.0f`.